### PR TITLE
Rename OptionalLocalDateTypeHandler to OptionalDateTypeHandler

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Tierline MyBatis Addons は、MyBatis で Java の `Optional` 型を扱うため
 
 #### テストクラスの命名
 
-- テスト対象クラス名 + `Test` (例: `OptionalLocalDateTypeHandlerTest`)
+- テスト対象クラス名 + `Test` (例: `OptionalDateTypeHandlerTest`)
 
 #### @DisplayName の使用
 
@@ -98,8 +98,8 @@ Tierline MyBatis Addons は、MyBatis で Java の `Optional` 型を扱うため
 - 例:
 
   ```java
-  @DisplayName("OptionalLocalDateTypeHandler のテスト")
-  class OptionalLocalDateTypeHandlerTest {
+  @DisplayName("OptionalDateTypeHandler のテスト")
+  class OptionalDateTypeHandlerTest {
     @Test
     @DisplayName("Optional に値がある場合、PreparedStatement に java.sql.Date として設定される")
     void testSetNonNullParameterWithPresentValue() { ... }

--- a/lib/src/main/java/com/tierline/mybatis/typehandler/OptionalDateTypeHandler.java
+++ b/lib/src/main/java/com/tierline/mybatis/typehandler/OptionalDateTypeHandler.java
@@ -12,7 +12,7 @@ import org.apache.ibatis.type.BaseTypeHandler;
 import org.apache.ibatis.type.JdbcType;
 
 /** MyBatis type handler for {@link Optional} of {@link LocalDate}. */
-public class OptionalLocalDateTypeHandler extends BaseTypeHandler<Optional<LocalDate>> {
+public class OptionalDateTypeHandler extends BaseTypeHandler<Optional<LocalDate>> {
 
   @Override
   public void setNonNullParameter(

--- a/lib/src/test/java/com/tierline/mybatis/typehandler/OptionalDateTypeHandlerTest.java
+++ b/lib/src/test/java/com/tierline/mybatis/typehandler/OptionalDateTypeHandlerTest.java
@@ -20,15 +20,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-/** Test class for {@link OptionalLocalDateTypeHandler}. */
-@DisplayName("OptionalLocalDateTypeHandler のテスト")
-class OptionalLocalDateTypeHandlerTest {
+/** Test class for {@link OptionalDateTypeHandler}. */
+@DisplayName("OptionalDateTypeHandler のテスト")
+class OptionalDateTypeHandlerTest {
 
-  private OptionalLocalDateTypeHandler handler;
+  private OptionalDateTypeHandler handler;
 
   @BeforeEach
   void setUp() {
-    handler = new OptionalLocalDateTypeHandler();
+    handler = new OptionalDateTypeHandler();
   }
 
   @Test


### PR DESCRIPTION
## 概要

Issue #8 に対応し、`OptionalLocalDateTypeHandler` を `OptionalDateTypeHandler` にリネームしました。

## 変更の理由

### 命名規則の統一
現在の命名は Java の型名 (`LocalDate`) を使用していますが、TypeHandler は RDB の型とのマッピングを行うため、RDB の型名を使用する方が適切です。

**変更前:**
- `OptionalLocalDateTypeHandler` - Java の型名 `LocalDate` を使用

**変更後:**
- `OptionalDateTypeHandler` - RDB の型名 `DATE` を使用

### 一貫性の向上
他の TypeHandler との命名を統一:
- `OptionalTimestampTypeHandler` - RDB の **TIMESTAMP** 型 ↔ Java の `OffsetDateTime`
- `OptionalDateTypeHandler` - RDB の **DATE** 型 ↔ Java の `LocalDate` ✅

この命名により、RDB の型から対応する TypeHandler を探しやすくなります。

## 変更内容

### 1. クラスのリネーム
- `OptionalLocalDateTypeHandler` → `OptionalDateTypeHandler`
- `OptionalLocalDateTypeHandlerTest` → `OptionalDateTypeHandlerTest`

### 2. ファイルのリネーム
- `OptionalLocalDateTypeHandler.java` → `OptionalDateTypeHandler.java`
- `OptionalLocalDateTypeHandlerTest.java` → `OptionalDateTypeHandlerTest.java`

### 3. @DisplayName の更新
- テストクラスの @DisplayName を新しいクラス名に更新

### 4. AGENTS.md の更新
- ドキュメントの例を新しいクラス名に更新

## テスト結果

✅ すべてのテストがパス
✅ ビルドが成功

```
./gradlew clean build
BUILD SUCCESSFUL in 371ms
```

## ⚠️ 破壊的変更

**これは破壊的変更です。**

既に `OptionalLocalDateTypeHandler` を使用しているユーザーは、MyBatis 設定ファイルのクラス名を更新する必要があります。

### マイグレーション例

```xml
<- DATE 型のカラムを Optional 変更前 -->
<typeHandler handler="com.tierline.mybatis.typehandler.OptionalLocalDateTypeHandler"/>

<- DATE 型のカラムを Optional 変更後 -->
<typeHandler handler="com.tierline.mybatis.typehandler.OptionalDateTypeHandler"/>
```

## 影響範囲

- バージョン 0.0.2 で `OptionalLocalDateTypeHandler` が導入されました
- まだ広く使用されていない可能性が高いため、早期のリネームが適切と判断

## 次のステップ

マージ後:
1. バージョンを 0.0.3 にアップ
2. リリースノートに破壊的変更を明記
3. マイグレーションガイドを提供

Closes #8