### PR TITLE
OptionalTypeHandler の修正と PostgreSQL 統合テストの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,78 @@
 
 以下のコマンドを実行することでローカルの Maven リポジトリに jar ファイルをインストールすることができる。
 
-    ./gradlew lib:publishToMavenLocal
+```bash
+./gradlew lib:publishToMavenLocal
+```
+
+## PostgreSQL 統合テスト
+
+### 概要
+
+PostgreSQL を使用した TypeHandler の統合テストです。
+
+### 前提条件
+
+Docker と Docker Compose がインストールされていること。
+
+### 使い方
+
+#### 1. PostgreSQL を起動
+
+```bash
+docker compose up -d
+
+# 起動確認
+docker compose ps
+```
+
+#### 2. テストを実行
+
+```bash
+# すべてのテスト（ユニットテスト + 統合テスト）
+./gradlew test
+
+# 統合テストのみ
+./gradlew test --tests PostgreSqlIntegrationTest
+```
+
+#### 3. PostgreSQL を停止
+
+```bash
+docker compose down
+```
+
+### 接続情報
+
+- ホスト: `localhost`
+- ポート: `65432` (デフォルトの 5432 との競合を避けるため)
+- データベース: `testdb`
+- ユーザー: `test`
+- パスワード: `test`
+
+### 注意事項
+
+- PostgreSQL が起動していない場合、統合テストは自動的にスキップされます
+- ユニットテストは PostgreSQL なしで実行できます
+- ポート 65432 が使用可能である必要があります
+
+### トラブルシューティング
+
+#### ポート 65432 が既に使用されている
+
+```bash
+# 使用中のポートを確認
+lsof -i:65432
+
+# 既存のプロセスを停止
+```
+
+#### PostgreSQL に接続できない
+
+```bash
+# コンテナのログを確認
+docker compose logs postgres
+
+# 接続テスト
+psql -h localhost -p 65432 -U test -d testdb
+```

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,19 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: mybatis-addons-test-db
+    environment:
+      POSTGRES_DB: testdb
+      POSTGRES_USER: test
+      POSTGRES_PASSWORD: test
+    ports:
+      - "65432:5432"
+    volumes:
+      - ./lib/src/test/resources/schema.sql:/docker-entrypoint-initdb.d/schema.sql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U test -d testdb"]
+      interval: 5s
+      timeout: 5s
+      retries: 5

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -20,7 +20,7 @@ plugins {
 }
 
 group = 'com.tierline'
-version = '0.0.2'
+version = '0.0.3'
 
 jar {
   archiveBaseName = rootProject.name

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -96,6 +96,8 @@ dependencies {
     // Test dependencies
     testImplementation 'org.mockito:mockito-core:5.20.0'
     testImplementation 'org.mockito:mockito-junit-jupiter:5.20.0'
+    testImplementation 'org.postgresql:postgresql:42.7.4'
+    testImplementation 'org.slf4j:slf4j-simple:1.7.36'
 }
 
 testing {
@@ -108,9 +110,36 @@ testing {
     }
 }
 
+// Configure test output
+tasks.named('test') {
+    testLogging {
+        events "passed", "skipped", "failed"
+        exceptionFormat "full"
+        showExceptions true
+        showCauses true
+        showStackTraces true
+
+        // Show test names as they execute
+        afterSuite { desc, result ->
+            if (!desc.parent) { // Will match the outermost suite
+                println "\nTest Results: ${result.resultType}"
+                println "Tests: ${result.testCount}, " +
+                        "Passed: ${result.successfulTestCount}, " +
+                        "Failed: ${result.failedTestCount}, " +
+                        "Skipped: ${result.skippedTestCount}"
+            }
+        }
+    }
+}
+
 // Apply a specific Java toolchain to ease working on different environments.
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(25)
     }
+}
+
+// Configure Java compiler options
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs += ['-Xlint:unchecked', '-Xlint:deprecation']
 }

--- a/lib/src/test/java/com/tierline/mybatis/integration/PostgreSqlIntegrationTest.java
+++ b/lib/src/test/java/com/tierline/mybatis/integration/PostgreSqlIntegrationTest.java
@@ -1,0 +1,248 @@
+package com.tierline.mybatis.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.Properties;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test for TypeHandlers with PostgreSQL.
+ *
+ * <p>Prerequisites: Start PostgreSQL with Docker Compose:
+ *
+ * <pre>
+ * docker-compose up -d
+ * </pre>
+ *
+ * <p>Run tests:
+ *
+ * <pre>
+ * ./gradlew test
+ * </pre>
+ *
+ * <p>Stop PostgreSQL:
+ *
+ * <pre>
+ * docker-compose down
+ * </pre>
+ */
+@DisplayName("PostgreSQL 統合テスト - TypeHandler の動作確認")
+class PostgreSqlIntegrationTest {
+
+  private static final String JDBC_URL = "jdbc:postgresql://localhost:65432/testdb";
+  private static final String USERNAME = "test";
+  private static final String PASSWORD = "test";
+
+  private static SqlSessionFactory sqlSessionFactory;
+  private static boolean postgresAvailable = false;
+
+  @BeforeAll
+  static void setUpClass() {
+    // Check if PostgreSQL is available
+    try (Connection conn = DriverManager.getConnection(JDBC_URL, USERNAME, PASSWORD)) {
+      postgresAvailable = true;
+
+      // Setup MyBatis
+      Properties properties = new Properties();
+      properties.setProperty("jdbc.driver", "org.postgresql.Driver");
+      properties.setProperty("jdbc.url", JDBC_URL);
+      properties.setProperty("jdbc.username", USERNAME);
+      properties.setProperty("jdbc.password", PASSWORD);
+
+      InputStream inputStream = Resources.getResourceAsStream("mybatis-config-integration.xml");
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(inputStream, properties);
+    } catch (SQLException | IOException e) {
+      System.err.println("⚠️  PostgreSQL is not available. Start it with: docker-compose up -d");
+      System.err.println("   Skipping integration tests.");
+    }
+  }
+
+  @AfterAll
+  static void tearDownClass() {
+    if (postgresAvailable) {
+      System.out.println(
+          "✅ Integration tests completed. Stop PostgreSQL with: docker-compose down");
+    }
+  }
+
+  @BeforeEach
+  void setUp() {
+    if (!postgresAvailable) {
+      org.junit.jupiter.api.Assumptions.assumeTrue(
+          false, "PostgreSQL not available. Start with: docker-compose up -d");
+    }
+
+    // Clean up test data
+    try (SqlSession session = sqlSessionFactory.openSession()) {
+      Connection conn = session.getConnection();
+      try (Statement stmt = conn.createStatement()) {
+        stmt.execute("TRUNCATE TABLE test_entity");
+      }
+      session.commit();
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  @DisplayName("すべての Optional フィールドに値がある場合、正しく保存・取得できる")
+  void testInsertAndSelectWithAllValues() {
+    TestEntity entity = new TestEntity();
+    entity.setId(1);
+    entity.setName(Optional.of("John Doe"));
+    entity.setAge(Optional.of(30));
+    entity.setSalary(Optional.of(50000L));
+    entity.setRate(Optional.of(0.15));
+    entity.setAmount(Optional.of(new BigDecimal("1234.56")));
+    entity.setActive(Optional.of(true));
+    entity.setBirthDate(Optional.of(LocalDate.of(1990, 1, 15)));
+    entity.setCreatedAt(
+        Optional.of(OffsetDateTime.of(2024, 1, 1, 10, 30, 0, 0, ZoneOffset.ofHours(9))));
+
+    try (SqlSession session = sqlSessionFactory.openSession()) {
+      TestEntityMapper mapper = session.getMapper(TestEntityMapper.class);
+      mapper.insert(entity);
+      session.commit();
+
+      TestEntity result = mapper.findById(1);
+
+      assertNotNull(result);
+      assertEquals(1, result.getId());
+      assertTrue(result.getName().isPresent());
+      assertEquals("John Doe", result.getName().get());
+      assertTrue(result.getAge().isPresent());
+      assertEquals(30, result.getAge().get());
+      assertTrue(result.getSalary().isPresent());
+      assertEquals(50000L, result.getSalary().get());
+      assertTrue(result.getRate().isPresent());
+      assertEquals(0.15, result.getRate().get(), 0.001);
+      assertTrue(result.getAmount().isPresent());
+      assertEquals(new BigDecimal("1234.56"), result.getAmount().get());
+      assertTrue(result.getActive().isPresent());
+      assertTrue(result.getActive().get());
+      assertTrue(result.getBirthDate().isPresent());
+      assertEquals(LocalDate.of(1990, 1, 15), result.getBirthDate().get());
+      assertTrue(result.getCreatedAt().isPresent());
+    }
+  }
+
+  @Test
+  @DisplayName("すべての Optional フィールドが空の場合、NULL として保存・取得できる")
+  void testInsertAndSelectWithEmptyOptionals() {
+    TestEntity entity = new TestEntity();
+    entity.setId(2);
+    entity.setName(Optional.empty());
+    entity.setAge(Optional.empty());
+    entity.setSalary(Optional.empty());
+    entity.setRate(Optional.empty());
+    entity.setAmount(Optional.empty());
+    entity.setActive(Optional.empty());
+    entity.setBirthDate(Optional.empty());
+    entity.setCreatedAt(Optional.empty());
+
+    try (SqlSession session = sqlSessionFactory.openSession()) {
+      TestEntityMapper mapper = session.getMapper(TestEntityMapper.class);
+      mapper.insert(entity);
+      session.commit();
+
+      TestEntity result = mapper.findById(2);
+
+      assertNotNull(result);
+      assertEquals(2, result.getId());
+      assertFalse(result.getName().isPresent());
+      assertFalse(result.getAge().isPresent());
+      assertFalse(result.getSalary().isPresent());
+      assertFalse(result.getRate().isPresent());
+      assertFalse(result.getAmount().isPresent());
+      assertFalse(result.getActive().isPresent());
+      assertFalse(result.getBirthDate().isPresent());
+      assertFalse(result.getCreatedAt().isPresent());
+    }
+  }
+
+  @Test
+  @DisplayName("Optional<Boolean> に false を設定した場合、正しく保存・取得できる")
+  void testBooleanFalseValue() {
+    TestEntity entity = new TestEntity();
+    entity.setId(3);
+    entity.setName(Optional.of("Test"));
+    entity.setAge(Optional.empty());
+    entity.setSalary(Optional.empty());
+    entity.setRate(Optional.empty());
+    entity.setAmount(Optional.empty());
+    entity.setActive(Optional.of(false));
+    entity.setBirthDate(Optional.empty());
+    entity.setCreatedAt(Optional.empty());
+
+    try (SqlSession session = sqlSessionFactory.openSession()) {
+      TestEntityMapper mapper = session.getMapper(TestEntityMapper.class);
+      mapper.insert(entity);
+      session.commit();
+
+      TestEntity result = mapper.findById(3);
+
+      assertNotNull(result);
+      assertTrue(result.getActive().isPresent());
+      assertFalse(result.getActive().get());
+    }
+  }
+
+  @Test
+  @DisplayName("一部のフィールドのみ値がある場合、正しく保存・取得できる")
+  void testPartialValues() {
+    TestEntity entity = new TestEntity();
+    entity.setId(4);
+    entity.setName(Optional.of("Partial Test"));
+    entity.setAge(Optional.of(25));
+    entity.setSalary(Optional.empty());
+    entity.setRate(Optional.empty());
+    entity.setAmount(Optional.of(new BigDecimal("999.99")));
+    entity.setActive(Optional.of(true));
+    entity.setBirthDate(Optional.empty());
+    entity.setCreatedAt(Optional.empty());
+
+    try (SqlSession session = sqlSessionFactory.openSession()) {
+      TestEntityMapper mapper = session.getMapper(TestEntityMapper.class);
+      mapper.insert(entity);
+      session.commit();
+
+      TestEntity result = mapper.findById(4);
+
+      assertNotNull(result);
+      assertTrue(result.getName().isPresent());
+      assertEquals("Partial Test", result.getName().get());
+      assertTrue(result.getAge().isPresent());
+      assertEquals(25, result.getAge().get());
+      assertFalse(result.getSalary().isPresent());
+      assertFalse(result.getRate().isPresent());
+      assertTrue(result.getAmount().isPresent());
+      assertEquals(new BigDecimal("999.99"), result.getAmount().get());
+      assertTrue(result.getActive().isPresent());
+      assertTrue(result.getActive().get());
+      assertFalse(result.getBirthDate().isPresent());
+      assertFalse(result.getCreatedAt().isPresent());
+    }
+  }
+}

--- a/lib/src/test/java/com/tierline/mybatis/integration/TestEntity.java
+++ b/lib/src/test/java/com/tierline/mybatis/integration/TestEntity.java
@@ -1,0 +1,91 @@
+package com.tierline.mybatis.integration;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+/** DTO for testing TypeHandlers with PostgreSQL. */
+public class TestEntity {
+  private Integer id;
+  private Optional<String> name;
+  private Optional<Integer> age;
+  private Optional<Long> salary;
+  private Optional<Double> rate;
+  private Optional<BigDecimal> amount;
+  private Optional<Boolean> active;
+  private Optional<LocalDate> birthDate;
+  private Optional<OffsetDateTime> createdAt;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public Optional<String> getName() {
+    return name;
+  }
+
+  public void setName(Optional<String> name) {
+    this.name = name;
+  }
+
+  public Optional<Integer> getAge() {
+    return age;
+  }
+
+  public void setAge(Optional<Integer> age) {
+    this.age = age;
+  }
+
+  public Optional<Long> getSalary() {
+    return salary;
+  }
+
+  public void setSalary(Optional<Long> salary) {
+    this.salary = salary;
+  }
+
+  public Optional<Double> getRate() {
+    return rate;
+  }
+
+  public void setRate(Optional<Double> rate) {
+    this.rate = rate;
+  }
+
+  public Optional<BigDecimal> getAmount() {
+    return amount;
+  }
+
+  public void setAmount(Optional<BigDecimal> amount) {
+    this.amount = amount;
+  }
+
+  public Optional<Boolean> getActive() {
+    return active;
+  }
+
+  public void setActive(Optional<Boolean> active) {
+    this.active = active;
+  }
+
+  public Optional<LocalDate> getBirthDate() {
+    return birthDate;
+  }
+
+  public void setBirthDate(Optional<LocalDate> birthDate) {
+    this.birthDate = birthDate;
+  }
+
+  public Optional<OffsetDateTime> getCreatedAt() {
+    return createdAt;
+  }
+
+  public void setCreatedAt(Optional<OffsetDateTime> createdAt) {
+    this.createdAt = createdAt;
+  }
+}

--- a/lib/src/test/java/com/tierline/mybatis/integration/TestEntityMapper.java
+++ b/lib/src/test/java/com/tierline/mybatis/integration/TestEntityMapper.java
@@ -1,0 +1,11 @@
+package com.tierline.mybatis.integration;
+
+import org.apache.ibatis.annotations.Param;
+
+/** MyBatis Mapper for TestEntity. */
+public interface TestEntityMapper {
+
+  void insert(TestEntity entity);
+
+  TestEntity findById(@Param("id") Integer id);
+}

--- a/lib/src/test/java/com/tierline/mybatis/typehandler/OptionalTypeHandlerTest.java
+++ b/lib/src/test/java/com/tierline/mybatis/typehandler/OptionalTypeHandlerTest.java
@@ -1,0 +1,320 @@
+package com.tierline.mybatis.typehandler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import org.apache.ibatis.type.JdbcType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** Test class for {@link OptionalTypeHandler}. */
+@DisplayName("OptionalTypeHandler のテスト")
+class OptionalTypeHandlerTest {
+
+  @Test
+  @DisplayName("Optional<String> に値がある場合、PreparedStatement に String として設定される")
+  void testSetNonNullParameterWithStringValue() throws SQLException {
+    OptionalTypeHandler<String> handler = new OptionalTypeHandler<>();
+    PreparedStatement ps = mock(PreparedStatement.class);
+    String testValue = "test string";
+    Optional<String> parameter = Optional.of(testValue);
+    int parameterIndex = 1;
+
+    handler.setNonNullParameter(ps, parameterIndex, parameter, JdbcType.VARCHAR);
+
+    verify(ps).setString(parameterIndex, testValue);
+  }
+
+  @Test
+  @DisplayName("Optional<OffsetDateTime> に値がある場合、PreparedStatement に Timestamp として設定される")
+  void testSetNonNullParameterWithOffsetDateTimeValue() throws SQLException {
+    OptionalTypeHandler<OffsetDateTime> handler = new OptionalTypeHandler<>();
+    PreparedStatement ps = mock(PreparedStatement.class);
+    OffsetDateTime testDateTime =
+        OffsetDateTime.of(2024, 1, 15, 10, 30, 0, 0, ZoneOffset.ofHours(9));
+    Optional<OffsetDateTime> parameter = Optional.of(testDateTime);
+    int parameterIndex = 1;
+
+    handler.setNonNullParameter(ps, parameterIndex, parameter, JdbcType.TIMESTAMP);
+
+    verify(ps).setTimestamp(parameterIndex, Timestamp.from(testDateTime.toInstant()));
+  }
+
+  @Test
+  @DisplayName("Optional が空の場合、PreparedStatement に NULL（VARCHAR型）が設定される")
+  void testSetNonNullParameterWithEmptyValueVarchar() throws SQLException {
+    OptionalTypeHandler<String> handler = new OptionalTypeHandler<>();
+    PreparedStatement ps = mock(PreparedStatement.class);
+    Optional<String> parameter = Optional.empty();
+    int parameterIndex = 1;
+
+    handler.setNonNullParameter(ps, parameterIndex, parameter, JdbcType.VARCHAR);
+
+    verify(ps).setNull(parameterIndex, Types.VARCHAR);
+  }
+
+  @Test
+  @DisplayName("Optional が空の場合、PreparedStatement に NULL（TIMESTAMP型）が設定される")
+  void testSetNonNullParameterWithEmptyValueTimestamp() throws SQLException {
+    OptionalTypeHandler<OffsetDateTime> handler = new OptionalTypeHandler<>();
+    PreparedStatement ps = mock(PreparedStatement.class);
+    Optional<OffsetDateTime> parameter = Optional.empty();
+    int parameterIndex = 1;
+
+    handler.setNonNullParameter(ps, parameterIndex, parameter, JdbcType.TIMESTAMP);
+
+    verify(ps).setNull(parameterIndex, Types.TIMESTAMP);
+  }
+
+  @Test
+  @DisplayName("Optional が空の場合、PreparedStatement に NULL（INTEGER型）が設定される")
+  void testSetNonNullParameterWithEmptyValueInteger() throws SQLException {
+    OptionalTypeHandler<Integer> handler = new OptionalTypeHandler<>();
+    PreparedStatement ps = mock(PreparedStatement.class);
+    Optional<Integer> parameter = Optional.empty();
+    int parameterIndex = 1;
+
+    handler.setNonNullParameter(ps, parameterIndex, parameter, JdbcType.INTEGER);
+
+    verify(ps).setNull(parameterIndex, Types.INTEGER);
+  }
+
+  @Test
+  @DisplayName("ResultSet からカラム名で String 値を取得すると、Optional<String> に変換される")
+  void testGetNullableResultByColumnNameWithString() throws SQLException {
+    OptionalTypeHandler<String> handler = new OptionalTypeHandler<>();
+    handler.init(new String[0]);
+    ResultSet rs = mock(ResultSet.class);
+    String columnName = "test_column";
+    String testValue = "test string";
+    when(rs.getObject(columnName)).thenReturn(testValue);
+    when(rs.wasNull()).thenReturn(false);
+
+    Optional<String> result = handler.getNullableResult(rs, columnName);
+
+    assertTrue(result.isPresent());
+    assertEquals(testValue, result.get());
+  }
+
+  @Test
+  @DisplayName("ResultSet からインデックスで String 値を取得すると、Optional<String> に変換される")
+  void testGetNullableResultByColumnIndexWithString() throws SQLException {
+    OptionalTypeHandler<String> handler = new OptionalTypeHandler<>();
+    handler.init(new String[0]);
+    ResultSet rs = mock(ResultSet.class);
+    int columnIndex = 1;
+    String testValue = "test value";
+    when(rs.getObject(columnIndex)).thenReturn(testValue);
+    when(rs.wasNull()).thenReturn(false);
+
+    Optional<String> result = handler.getNullableResult(rs, columnIndex);
+
+    assertTrue(result.isPresent());
+    assertEquals(testValue, result.get());
+  }
+
+  @Test
+  @DisplayName("CallableStatement から String 値を取得すると、Optional<String> に変換される")
+  void testGetNullableResultFromCallableStatementWithString() throws SQLException {
+    OptionalTypeHandler<String> handler = new OptionalTypeHandler<>();
+    handler.init(new String[0]);
+    CallableStatement cs = mock(CallableStatement.class);
+    int columnIndex = 1;
+    String testValue = "callable test";
+    when(cs.getObject(columnIndex)).thenReturn(testValue);
+    when(cs.wasNull()).thenReturn(false);
+
+    Optional<String> result = handler.getNullableResult(cs, columnIndex);
+
+    assertTrue(result.isPresent());
+    assertEquals(testValue, result.get());
+  }
+
+  @Test
+  @DisplayName("String を設定して取得すると、元の値が正しく復元される（往復変換）")
+  void testRoundTripConversionWithString() throws SQLException {
+    OptionalTypeHandler<String> handler = new OptionalTypeHandler<>();
+    handler.init(new String[0]);
+    PreparedStatement ps = mock(PreparedStatement.class);
+    ResultSet rs = mock(ResultSet.class);
+    String originalValue = "round trip test";
+    Optional<String> original = Optional.of(originalValue);
+    int parameterIndex = 1;
+
+    handler.setNonNullParameter(ps, parameterIndex, original, JdbcType.VARCHAR);
+
+    verify(ps).setString(parameterIndex, originalValue);
+
+    when(rs.getObject(parameterIndex)).thenReturn(originalValue);
+    when(rs.wasNull()).thenReturn(false);
+    Optional<String> result = handler.getNullableResult(rs, parameterIndex);
+
+    assertTrue(result.isPresent());
+    assertEquals(originalValue, result.get());
+  }
+
+  @Test
+  @DisplayName("Optional<Integer> に値がある場合、PreparedStatement に Integer として設定される")
+  void testSetNonNullParameterWithIntegerValue() throws SQLException {
+    OptionalTypeHandler<Integer> handler = new OptionalTypeHandler<>();
+    PreparedStatement ps = mock(PreparedStatement.class);
+    Integer testValue = 42;
+    Optional<Integer> parameter = Optional.of(testValue);
+    int parameterIndex = 1;
+
+    handler.setNonNullParameter(ps, parameterIndex, parameter, JdbcType.INTEGER);
+
+    verify(ps).setInt(parameterIndex, testValue);
+  }
+
+  @Test
+  @DisplayName("Optional<BigDecimal> に値がある場合、PreparedStatement に BigDecimal として設定される")
+  void testSetNonNullParameterWithBigDecimalValue() throws SQLException {
+    OptionalTypeHandler<java.math.BigDecimal> handler = new OptionalTypeHandler<>();
+    PreparedStatement ps = mock(PreparedStatement.class);
+    java.math.BigDecimal testValue = new java.math.BigDecimal("123.45");
+    Optional<java.math.BigDecimal> parameter = Optional.of(testValue);
+    int parameterIndex = 1;
+
+    handler.setNonNullParameter(ps, parameterIndex, parameter, JdbcType.NUMERIC);
+
+    verify(ps).setBigDecimal(parameterIndex, testValue);
+  }
+
+  @Test
+  @DisplayName("Optional<Long> に値がある場合、PreparedStatement に Long として設定される")
+  void testSetNonNullParameterWithLongValue() throws SQLException {
+    OptionalTypeHandler<Long> handler = new OptionalTypeHandler<>();
+    PreparedStatement ps = mock(PreparedStatement.class);
+    Long testValue = 9876543210L;
+    Optional<Long> parameter = Optional.of(testValue);
+    int parameterIndex = 1;
+
+    handler.setNonNullParameter(ps, parameterIndex, parameter, JdbcType.BIGINT);
+
+    verify(ps).setLong(parameterIndex, testValue);
+  }
+
+  @Test
+  @DisplayName("Optional<Double> に値がある場合、PreparedStatement に Double として設定される")
+  void testSetNonNullParameterWithDoubleValue() throws SQLException {
+    OptionalTypeHandler<Double> handler = new OptionalTypeHandler<>();
+    PreparedStatement ps = mock(PreparedStatement.class);
+    Double testValue = 3.14159;
+    Optional<Double> parameter = Optional.of(testValue);
+    int parameterIndex = 1;
+
+    handler.setNonNullParameter(ps, parameterIndex, parameter, JdbcType.DOUBLE);
+
+    verify(ps).setDouble(parameterIndex, testValue);
+  }
+
+  @Test
+  @DisplayName("Integer を設定して取得すると、元の値が正しく復元される（往復変換）")
+  void testRoundTripConversionWithInteger() throws SQLException {
+    OptionalTypeHandler<Integer> handler = new OptionalTypeHandler<>();
+    handler.init(new Integer[0]);
+    PreparedStatement ps = mock(PreparedStatement.class);
+    ResultSet rs = mock(ResultSet.class);
+    Integer originalValue = 999;
+    Optional<Integer> original = Optional.of(originalValue);
+    int parameterIndex = 1;
+
+    handler.setNonNullParameter(ps, parameterIndex, original, JdbcType.INTEGER);
+
+    verify(ps).setInt(parameterIndex, originalValue);
+
+    when(rs.getObject(parameterIndex)).thenReturn(originalValue);
+    when(rs.wasNull()).thenReturn(false);
+    Optional<Integer> result = handler.getNullableResult(rs, parameterIndex);
+
+    assertTrue(result.isPresent());
+    assertEquals(originalValue, result.get());
+  }
+
+  @Test
+  @DisplayName("BigDecimal を設定して取得すると、元の値が正しく復元される（往復変換）")
+  void testRoundTripConversionWithBigDecimal() throws SQLException {
+    OptionalTypeHandler<java.math.BigDecimal> handler = new OptionalTypeHandler<>();
+    handler.init(new java.math.BigDecimal[0]);
+    PreparedStatement ps = mock(PreparedStatement.class);
+    ResultSet rs = mock(ResultSet.class);
+    java.math.BigDecimal originalValue = new java.math.BigDecimal("9999.99");
+    Optional<java.math.BigDecimal> original = Optional.of(originalValue);
+    int parameterIndex = 1;
+
+    handler.setNonNullParameter(ps, parameterIndex, original, JdbcType.NUMERIC);
+
+    verify(ps).setBigDecimal(parameterIndex, originalValue);
+
+    when(rs.getObject(parameterIndex)).thenReturn(originalValue);
+    when(rs.wasNull()).thenReturn(false);
+    Optional<java.math.BigDecimal> result = handler.getNullableResult(rs, parameterIndex);
+
+    assertTrue(result.isPresent());
+    assertEquals(originalValue, result.get());
+  }
+
+  @Test
+  @DisplayName("Optional<Boolean> に true がある場合、PreparedStatement に Boolean として設定される")
+  void testSetNonNullParameterWithBooleanTrueValue() throws SQLException {
+    OptionalTypeHandler<Boolean> handler = new OptionalTypeHandler<>();
+    PreparedStatement ps = mock(PreparedStatement.class);
+    Boolean testValue = true;
+    Optional<Boolean> parameter = Optional.of(testValue);
+    int parameterIndex = 1;
+
+    handler.setNonNullParameter(ps, parameterIndex, parameter, JdbcType.BIT);
+
+    verify(ps).setBoolean(parameterIndex, testValue);
+  }
+
+  @Test
+  @DisplayName("Optional<Boolean> に false がある場合、PreparedStatement に Boolean として設定される")
+  void testSetNonNullParameterWithBooleanFalseValue() throws SQLException {
+    OptionalTypeHandler<Boolean> handler = new OptionalTypeHandler<>();
+    PreparedStatement ps = mock(PreparedStatement.class);
+    Boolean testValue = false;
+    Optional<Boolean> parameter = Optional.of(testValue);
+    int parameterIndex = 1;
+
+    handler.setNonNullParameter(ps, parameterIndex, parameter, JdbcType.BIT);
+
+    verify(ps).setBoolean(parameterIndex, testValue);
+  }
+
+  @Test
+  @DisplayName("Boolean を設定して取得すると、元の値が正しく復元される（往復変換）")
+  void testRoundTripConversionWithBoolean() throws SQLException {
+    OptionalTypeHandler<Boolean> handler = new OptionalTypeHandler<>();
+    handler.init(new Boolean[0]);
+    PreparedStatement ps = mock(PreparedStatement.class);
+    ResultSet rs = mock(ResultSet.class);
+    Boolean originalValue = true;
+    Optional<Boolean> original = Optional.of(originalValue);
+    int parameterIndex = 1;
+
+    handler.setNonNullParameter(ps, parameterIndex, original, JdbcType.BIT);
+
+    verify(ps).setBoolean(parameterIndex, originalValue);
+
+    when(rs.getObject(parameterIndex)).thenReturn(originalValue);
+    when(rs.wasNull()).thenReturn(false);
+    Optional<Boolean> result = handler.getNullableResult(rs, parameterIndex);
+
+    assertTrue(result.isPresent());
+    assertEquals(originalValue, result.get());
+  }
+}

--- a/lib/src/test/resources/com/tierline/mybatis/integration/TestEntityMapper.xml
+++ b/lib/src/test/resources/com/tierline/mybatis/integration/TestEntityMapper.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.tierline.mybatis.integration.TestEntityMapper">
+
+  <resultMap id="testEntityResultMap" type="com.tierline.mybatis.integration.TestEntity">
+    <id property="id" column="id" />
+    <result property="name" column="name"
+            javaType="java.util.Optional"
+            jdbcType="VARCHAR"
+            typeHandler="com.tierline.mybatis.typehandler.OptionalTypeHandler"/>
+    <result property="age" column="age"
+            javaType="java.util.Optional"
+            jdbcType="INTEGER"
+            typeHandler="com.tierline.mybatis.typehandler.OptionalTypeHandler"/>
+    <result property="salary" column="salary"
+            javaType="java.util.Optional"
+            jdbcType="BIGINT"
+            typeHandler="com.tierline.mybatis.typehandler.OptionalTypeHandler"/>
+    <result property="rate" column="rate"
+            javaType="java.util.Optional"
+            jdbcType="DOUBLE"
+            typeHandler="com.tierline.mybatis.typehandler.OptionalTypeHandler"/>
+    <result property="amount" column="amount"
+            javaType="java.util.Optional"
+            jdbcType="NUMERIC"
+            typeHandler="com.tierline.mybatis.typehandler.OptionalTypeHandler"/>
+    <result property="active" column="active"
+            javaType="java.util.Optional"
+            jdbcType="BIT"
+            typeHandler="com.tierline.mybatis.typehandler.OptionalTypeHandler"/>
+    <result property="birthDate" column="birth_date"
+            javaType="java.util.Optional"
+            jdbcType="DATE"
+            typeHandler="com.tierline.mybatis.typehandler.OptionalDateTypeHandler"/>
+    <result property="createdAt" column="created_at"
+            javaType="java.util.Optional"
+            jdbcType="TIMESTAMP"
+            typeHandler="com.tierline.mybatis.typehandler.OptionalTimestampTypeHandler"/>
+  </resultMap>
+
+  <insert id="insert" parameterType="com.tierline.mybatis.integration.TestEntity">
+    INSERT INTO test_entity (id, name, age, salary, rate, amount, active, birth_date, created_at)
+    VALUES (
+      #{id},
+      #{name, javaType=java.util.Optional, jdbcType=VARCHAR, typeHandler=com.tierline.mybatis.typehandler.OptionalTypeHandler},
+      #{age, javaType=java.util.Optional, jdbcType=INTEGER, typeHandler=com.tierline.mybatis.typehandler.OptionalTypeHandler},
+      #{salary, javaType=java.util.Optional, jdbcType=BIGINT, typeHandler=com.tierline.mybatis.typehandler.OptionalTypeHandler},
+      #{rate, javaType=java.util.Optional, jdbcType=DOUBLE, typeHandler=com.tierline.mybatis.typehandler.OptionalTypeHandler},
+      #{amount, javaType=java.util.Optional, jdbcType=NUMERIC, typeHandler=com.tierline.mybatis.typehandler.OptionalTypeHandler},
+      #{active, javaType=java.util.Optional, jdbcType=BIT, typeHandler=com.tierline.mybatis.typehandler.OptionalTypeHandler},
+      #{birthDate, javaType=java.util.Optional, jdbcType=DATE, typeHandler=com.tierline.mybatis.typehandler.OptionalDateTypeHandler},
+      #{createdAt, javaType=java.util.Optional, jdbcType=TIMESTAMP, typeHandler=com.tierline.mybatis.typehandler.OptionalTimestampTypeHandler}
+    )
+  </insert>
+
+  <select id="findById" resultMap="testEntityResultMap">
+    SELECT * FROM test_entity WHERE id = #{id}
+  </select>
+
+</mapper>

--- a/lib/src/test/resources/mybatis-config-integration.xml
+++ b/lib/src/test/resources/mybatis-config-integration.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration
+  PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+  "https://mybatis.org/dtd/mybatis-3-config.dtd">
+<configuration>
+  <typeHandlers>
+    <typeHandler handler="com.tierline.mybatis.typehandler.OptionalTypeHandler" javaType="java.util.Optional" jdbcType="BIT"/>
+    <typeHandler handler="com.tierline.mybatis.typehandler.OptionalTypeHandler" javaType="java.util.Optional" jdbcType="INTEGER"/>
+    <typeHandler handler="com.tierline.mybatis.typehandler.OptionalTypeHandler" javaType="java.util.Optional" jdbcType="BIGINT"/>
+    <typeHandler handler="com.tierline.mybatis.typehandler.OptionalTypeHandler" javaType="java.util.Optional" jdbcType="DOUBLE"/>
+    <typeHandler handler="com.tierline.mybatis.typehandler.OptionalTypeHandler" javaType="java.util.Optional" jdbcType="NUMERIC"/>
+    <typeHandler handler="com.tierline.mybatis.typehandler.OptionalTypeHandler" javaType="java.util.Optional" jdbcType="VARCHAR"/>
+    <typeHandler handler="com.tierline.mybatis.typehandler.OptionalTimestampTypeHandler" javaType="java.util.Optional" jdbcType="TIMESTAMP"/>
+    <typeHandler handler="com.tierline.mybatis.typehandler.OptionalDateTypeHandler" javaType="java.util.Optional" jdbcType="DATE"/>
+  </typeHandlers>
+
+  <environments default="development">
+    <environment id="development">
+      <transactionManager type="JDBC"/>
+      <dataSource type="POOLED">
+        <property name="driver" value="${jdbc.driver}"/>
+        <property name="url" value="${jdbc.url}"/>
+        <property name="username" value="${jdbc.username}"/>
+        <property name="password" value="${jdbc.password}"/>
+      </dataSource>
+    </environment>
+  </environments>
+
+  <mappers>
+    <mapper resource="com/tierline/mybatis/integration/TestEntityMapper.xml"/>
+  </mappers>
+</configuration>

--- a/lib/src/test/resources/schema.sql
+++ b/lib/src/test/resources/schema.sql
@@ -1,0 +1,12 @@
+-- Test table for integration testing
+CREATE TABLE test_entity (
+    id INTEGER PRIMARY KEY,
+    name VARCHAR(100),
+    age INTEGER,
+    salary BIGINT,
+    rate DOUBLE PRECISION,
+    amount NUMERIC(10, 2),
+    active BOOLEAN,
+    birth_date DATE,
+    created_at TIMESTAMP WITH TIME ZONE
+);


### PR DESCRIPTION
OptionalTypeHandler のバグ修正と、実際のデータベースを使った統合テストを追加しました。

## 変更内容

### OptionalTypeHandler の修正
- `getNullableResult` メソッドで null チェックを追加（NPE の修正）
- `setNull` メソッドで DOUBLE 型をサポート

### 統合テストの追加
- PostgreSQL を使った統合テストを追加
- TestEntity DTO とマッパーを作成
- MyBatis-config.xml でのTypeHandler設定をテスト
- docker-compose.yml で PostgreSQL 環境を構築

### ドキュメント更新
- README.md に統合テストの実行方法を追記

Closes #11